### PR TITLE
Fix Fragment Lifecycle initialization of Presenter

### DIFF
--- a/app/src/main/java/com/example/android/testing/notes/notes/NotesFragment.java
+++ b/app/src/main/java/com/example/android/testing/notes/notes/NotesFragment.java
@@ -67,6 +67,7 @@ public class NotesFragment extends Fragment implements NotesContract.View {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mListAdapter = new NotesAdapter(new ArrayList<Note>(0), mItemListener);
+        mActionsListener = new NotesPresenter(Injection.provideNotesRepository(), this);
     }
 
     @Override
@@ -80,9 +81,6 @@ public class NotesFragment extends Fragment implements NotesContract.View {
         super.onActivityCreated(savedInstanceState);
 
         setRetainInstance(true);
-
-        mActionsListener = new NotesPresenter(Injection.provideNotesRepository(), this);
-
     }
 
     @Override


### PR DESCRIPTION
Looking at the life cycle of a Fragment from the documentation I see the onActivityCreated() will be called after the onCreateView()
http://developer.android.com/intl/es/reference/android/app/Fragment.html#Lifecycle

Then reading the current onCreateView() I see the NotesPresenter's object will be used in line 132 but it is only created later on inside onActivityCreated(), therefore I understand it's more logical to create the object before it's used, for example in onCreate().
https://github.com/googlecodelabs/android-testing/blob/master/app/src/main/java/com/example/android/testing/notes/notes/NotesFragment.java#L132

Because the NotesPresenter's object is only used inside the listener, it's probably safe to execute this code. So this PR is really more a possible bug question about: what is the correct place to initialize the NotesPresenter? Is it wrong to do it in onCreate() instead of onActivityCreated()?