### PR TITLE
Add explicit flavor dimensions for Gradle 3+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,13 +21,16 @@ android {
         }
     }
 
+    flavorDimensions "tier"
+
     // If you need to add more flavors, consider using flavor dimensions.
     productFlavors {
         mock {
             applicationIdSuffix = ".mock"
+            dimension "tier"
         }
         prod {
-
+            dimension "tier"
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,16 +21,14 @@ android {
         }
     }
 
-    flavorDimensions "tier"
+    flavorDimensions "default"
 
     // If you need to add more flavors, consider using flavor dimensions.
     productFlavors {
         mock {
             applicationIdSuffix = ".mock"
-            dimension "tier"
         }
         prod {
-            dimension "tier"
         }
     }
 


### PR DESCRIPTION
Otherwise this results in a build error in the preview versions of Android Studio.

The usage of `"tier"` was chosen to conform to the example given by the Android Studio [migration help linke](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html).