### PR TITLE
remove depracted setting from gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
The option `android.enableUnitTestBinaryResources=true` is deprecated and prevents the app from building.