### PR TITLE
Replace google-github-actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -87,13 +87,11 @@ jobs:
           name: app-debug-androidTest
 
       - name: Login to Google Cloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
-          version: '281.0.0'
+          project_id: ${{ secrets.FIREBASE_PROJECT_ID }}
           service_account_key: ${{ secrets.FTL_KEY_BASE64 }}
-
-      - name: Set current project
-        run: gcloud config set project ${{ secrets.FIREBASE_PROJECT_ID }}
+          export_default_credentials: true
 
       - name: Run Instrumentation Tests in Firebase Test Lab
         run: gcloud firebase test android run --type instrumentation --app app-debug/app-debug.apk --test app-debug-androidTest/app-debug-androidTest.apk --device model=Pixel2,version=28,locale=pl,orientation=portrait


### PR DESCRIPTION
Deprecated GooglePlatform/github-actions

Use instead of [Set up gcloud Cloud SDK environment](https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment)