### PR TITLE
Update LiveDataTestUtil.kt

### DIFF
--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/LiveDataTestUtil.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/LiveDataTestUtil.kt
@@ -53,7 +53,7 @@ fun <T> LiveData<T>.getOrAwaitValue(
             throw TimeoutException("LiveData value was never set.")
         }
 
-    } finally {
+    } catch(e: TimeoutException) {
         this.removeObserver(observer)
     }
 


### PR DESCRIPTION
I think we should use `catch` instead of `finally` because `finally` is always executed. 

Imagine when the `LiveData` value was set, the `Observer.onChanged()` method is triggered and removing the observer on `this@getOrAwaitValue.removeObserver(this)`.  So when we using `finally`, the `Observer` which we deleted earlier will be removed again which would be wasting.