### PR TITLE
Fixing java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableUnitTestBinaryResources=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
The starter code doesn't work with a new version of Android Studio like Arctic Fox, it seems to update Gradle, and removing the enableUnitTestBinaryResources configuration solved the problem, at least for me. Doing some research, it seems to be related to new Android projects using Java 11 as the default starting from Gradle 4.