### PR TITLE
Update to Room 2.4.0 to resolve build issues on Apple Silicon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     junitVersion = '4.13.2'
     materialVersion = '1.4.0'
     recyclerViewVersion = '1.2.1'
-    roomVersion = '2.3.0'
+    roomVersion = '2.4.0'
     rulesVersion = '1.0.1'
     swipeRefreshLayoutVersion = '1.1.0'
     timberVersion = '4.7.1'


### PR DESCRIPTION
The build fails when compiling on Apple Silicon. This is due to a bug in the 2.3.0 version of the Room library dependency.

Room 2.4.0 included a fix to resolve the issue. See https://developer.android.com/jetpack/androidx/releases/room#2.4.0-alpha03 and https://issuetracker.google.com/issues/174695268.

